### PR TITLE
create images directory before listing cached images

### DIFF
--- a/images/cached.go
+++ b/images/cached.go
@@ -28,6 +28,10 @@ func Remove(imageName string) error {
 func listCachedImages() ([]string, error) {
 	baseDir := db.ImagesDir + string(os.PathSeparator)
 
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return nil, err
+	}
+
 	images := make([]string, 0)
 
 	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Fixes:
```
➜  ~/vermin master ✗  ./vermin images
lstat /home/dawidd6/.vermin/images/: no such file or directory
```