### PR TITLE
trigger workflow run on push to master branch, tags or pull requests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,12 @@
 name: Go
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Currently the workflow is run only on pushes to branches created in this repo, or on tags pushes.
After this PR, the workflow will run on push to master branch in this repo, on tags pushes prefixed with `v` and also on pull requests from forks.