### PR TITLE
Skip the bridgeinfo split in case of carriage return

### DIFF
--- a/hypervisor/virtualbox/bridgedifs.go
+++ b/hypervisor/virtualbox/bridgedifs.go
@@ -19,6 +19,10 @@ func findBridgeInfo(keys ...string) ([]string, error) {
 	for _, line := range lines {
 		s := strings.SplitN(line, ":", 2)
 
+		if len(s) < 2 {
+			continue // Skip the line in case of carriage return
+		}
+
 		key := strings.TrimSpace(s[0])
 		value := strings.TrimSpace(s[1])
 		elements[key] = value


### PR DESCRIPTION
issue arises when getting bridgeinfo for some PC/laptops the bridgelist difs 

see attached debugger image

<img width="917" alt="Screenshot 2024-03-19 220439" src="https://github.com/mhewedy/vermin/assets/22194681/b6fdd1be-63b3-4979-8da9-0ba67409f7f4">


closes #40 
closes #41 